### PR TITLE
Bug/discord auth bug

### DIFF
--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -45,9 +45,9 @@ const clients = [
 
 const Home = () => {
     const auth = useAuthContext()
-
-    if (auth?.user === undefined) return <Spinner />
-    if (auth?.user === "unauthenticated" || auth?.user === null) return redirect('/')
+    
+    if (!auth?.user) return <Spinner />
+    if (auth?.isAuthenticated() === "unauthenticated" || auth?.user === null) return redirect('/')
 
     return (
         <div className="flex flex-wrap gap-x-[2%] gap-y-4 justify-center">

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -5,7 +5,7 @@ module.exports = {
     authDiscord: passport.authenticate("discord"),
     authDiscordCallback: passport.authenticate("discord", {
         failureRedirect: process.env.FRONTEND_URL,
-        successRedirect: `${process.env.FRONTEND_URL}/home`
+        successRedirect: `${process.env.FRONTEND_URL}/`
     }),
     logout: (req, res, next) => {
         const username = req.user.username

--- a/server/controllers/auth.js
+++ b/server/controllers/auth.js
@@ -5,7 +5,7 @@ module.exports = {
     authDiscord: passport.authenticate("discord"),
     authDiscordCallback: passport.authenticate("discord", {
         failureRedirect: process.env.FRONTEND_URL,
-        successRedirect: `${process.env.FRONTEND_URL}/`
+        successRedirect: `${process.env.FRONTEND_URL}/home`
     }),
     logout: (req, res, next) => {
         const username = req.user.username


### PR DESCRIPTION
The issue I think occurs when Discord callback sends the signed user to /home right away, the auth context won't get updated right away. That results in the user being null and isAuthenticated being "unauthenticated" 

So I fixed the Spinner Component, Now it will work when the user signs in but waiting for authContext to provide a confirmation
Also, I fixed the auth?.isAuthenticated() == "unauthenticated" to get the proper value to compare it with the string "unauthenticated"

This should fix the bug, When the user signs in, there should be a spinning component for a second, and then the home page populated with client cards from the database.

close #3 

This should be tested in a production environment, just to be sure. 
