### PR TITLE
Client data fetching on home page & bugfixes

### DIFF
--- a/client/app/admin/page.jsx
+++ b/client/app/admin/page.jsx
@@ -3,6 +3,7 @@
 import { useAuthContext } from 'contexts/AuthContext'
 import Spinner from '@components/ui/Spinner'
 import { useState } from 'react'
+import { redirect } from 'next/navigation'
 import Alert from '@components/ui/Alert'
 
 const page = () => {
@@ -25,8 +26,8 @@ const page = () => {
         }
     }
 
-    if (!auth?.user) return <Spinner />
-    if (auth?.isAuthenticated() === "unauthenticated" || auth?.user === null) return redirect('/')
+    if (!auth?.checkAuth) return <Spinner />
+    if (auth?.isAuthenticated() === "unauthenticated") return redirect('/')
     if (auth?.user && !auth?.user.admin) return redirect('/home')
 
     return (

--- a/client/app/admin/page.jsx
+++ b/client/app/admin/page.jsx
@@ -1,0 +1,48 @@
+"use client"
+
+import { useAuthContext } from 'contexts/AuthContext'
+import Spinner from '@components/ui/Spinner'
+import { useState } from 'react'
+import Alert from '@components/ui/Alert'
+
+const page = () => {
+    const auth = useAuthContext()
+    const [alert, setAlert] = useState({ message: '', type: '' })
+
+    const loadMockClients = async (e) => {
+        e.preventDefault()
+        const response = await fetch("/server/dev/loadmockclients", {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            credentials: 'include'
+        })
+        if (response.ok) {
+            setAlert({ message: 'Mock clients have been added to the DB', type: 'success' })
+        } else {
+            setAlert({ message: 'Failed to add mock clients to the DB', type: 'error' })
+        }
+    }
+
+    if (!auth?.user) return <Spinner />
+    if (auth?.isAuthenticated() === "unauthenticated" || auth?.user === null) return redirect('/')
+    if (auth?.user && !auth?.user.admin) return redirect('/home')
+
+    return (
+        <section className="flex flex-col gap-4 justify-center items-center w-full max-w-lg mx-auto">
+            {alert.message && <Alert message={alert.message} alertType={alert.type} />}
+            <h2 className="text-center">Admin Dashboard</h2>
+            {process.env.NEXT_PUBLIC_NODE_ENV === 'local' &&
+                <form onSubmit={e => loadMockClients(e)} className="flex flex-col gap-4 w-full">
+                    <hr />
+                    <h3 className="text-center">Dev Environment & Testing</h3>
+                    <input type="submit" value="Load Mock Clients" className="btn btn-sm" />
+                </form>
+            }
+
+        </section>
+    )
+}
+
+export default page

--- a/client/app/admin/page.jsx
+++ b/client/app/admin/page.jsx
@@ -27,7 +27,7 @@ const page = () => {
     }
 
     if (!auth?.checkAuth) return <Spinner />
-    if (auth?.isAuthenticated() === "unauthenticated") return redirect('/')
+    if (auth?.isAuthenticated === "unauthenticated") return redirect('/')
     if (auth?.user && !auth?.user.admin) return redirect('/home')
 
     return (

--- a/client/app/client/add/page.jsx
+++ b/client/app/client/add/page.jsx
@@ -33,7 +33,7 @@ const AddClient = () => {
     if (doRedirect) redirect('/home')
 
     if (!auth?.checkAuth) return <Spinner />
-    if (auth?.user === "unauthenticated") return redirect('/')
+    if (auth?.isAuthenticated === "unauthenticated") return redirect('/')
 
     return (
         <form onSubmit={(e) => addClient(e)}>

--- a/client/app/client/add/page.jsx
+++ b/client/app/client/add/page.jsx
@@ -32,7 +32,7 @@ const AddClient = () => {
     }
     if (doRedirect) redirect('/home')
 
-    if (!auth?.user) return <Spinner />
+    if (!auth?.checkAuth) return <Spinner />
     if (auth?.user === "unauthenticated") return redirect('/')
 
     return (

--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -5,48 +5,17 @@ import Spinner from '@components/ui/Spinner'
 import ClientCard from '@components/client/ClientCard'
 import { useAuthContext } from 'contexts/AuthContext'
 import ActionMenu from '@components/ui/ActionMenu'
-
-const clients = [
-    {
-        name: 'Outshine Salon',
-        businessType: 'hair salon',
-        phone: '(904) 756-2648',
-        email: 'outshine@salon.com',
-        address: '555 Main Street, Houston, TX 12345'
-    },
-    {
-        name: 'Homegrown Brunch Cafe',
-        businessType: 'restaurant',
-        phone: '(944) 724-1618',
-        email: 'homegrown@brunch.com',
-        address: '555 Main Street, Houston, TX 12345'
-    },
-    {
-        name: 'Functional Fitness',
-        businessType: 'gym',
-        phone: '(346) 754-1577',
-        email: 'functional@fitness.com',
-        address: '555 Main Street, Houston, TX 12345'
-    },
-    {
-        name: 'O-Marketing',
-        businessType: 'marketing',
-        phone: '(246) 755-1447',
-        email: 'o@marketing.com',
-        address: '555 Main Street, Houston, TX 12345'
-    },
-    {
-        name: 'Nails Plus',
-        businessType: 'nail salon',
-        phone: '(166) 733-1248',
-        email: 'nails@plus.com',
-        address: '555 Main Street, Houston, TX 12345'
-    }
-]
+import { useState, useEffect } from 'react'
+import { fetchClients } from '@utils/client'
 
 const Home = () => {
     const auth = useAuthContext()
-    
+    const [clients, setClients] = useState(null)
+
+    useEffect(() => {
+        fetchClients().then(data => setClients(data))
+    }, [auth?.user])
+
     if (!auth?.user) return <Spinner />
     if (auth?.isAuthenticated() === "unauthenticated" || auth?.user === null) return redirect('/')
 
@@ -56,9 +25,13 @@ const Home = () => {
                 <ActionMenu />
             </div>
             <div className="flex flex-wrap gap-x-[2%] gap-y-4 justify-center">
-                {clients.map((client, index) => {
-                    return <ClientCard client={client} key={index} />
-                })}
+                {clients === null && <Spinner />}
+                {clients && clients.length > 0
+                    ? clients.map((client, index) => {
+                        return <ClientCard client={client} key={index} />
+                    })
+                    : <p>You have not added any clients!</p>
+                }
             </div>
         </>
     )

--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -16,8 +16,8 @@ const Home = () => {
         fetchClients().then(data => setClients(data))
     }, [auth?.user])
 
-    if (!auth?.user) return <Spinner />
-    if (auth?.isAuthenticated() === "unauthenticated" || auth?.user === null) return redirect('/')
+    if (!auth?.checkAuth) return <Spinner />
+    if (auth?.isAuthenticated() === "unauthenticated") return redirect('/')
 
     return (
         <>

--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -17,7 +17,7 @@ const Home = () => {
     }, [auth?.user])
 
     if (!auth?.checkAuth) return <Spinner />
-    if (auth?.isAuthenticated() === "unauthenticated") return redirect('/')
+    if (auth?.isAuthenticated === "unauthenticated") return redirect('/')
 
     return (
         <>

--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -27,11 +27,11 @@ const Home = () => {
             <div className="flex flex-wrap gap-x-[2%] gap-y-4 justify-center">
                 {clients === null && <Spinner />}
                 {clients && clients.length > 0
-                    ? clients.map((client, index) => {
+                    && clients.map((client, index) => {
                         return <ClientCard client={client} key={index} />
                     })
-                    : <p>You have not added any clients!</p>
                 }
+                {clients && clients.length === 0 && <p>You have not added any clients!</p>}
             </div>
         </>
     )

--- a/client/app/outreach/add/page.jsx
+++ b/client/app/outreach/add/page.jsx
@@ -80,7 +80,7 @@ const AddOutreach = () => {
     }
     if (doRedirect) redirect('/home')
 
-    if (!auth?.user) return <Spinner />
+    if (!auth?.checkAuth) return <Spinner />
     if (auth?.user === "unauthenticated") return redirect('/')
 
     return (

--- a/client/app/outreach/add/page.jsx
+++ b/client/app/outreach/add/page.jsx
@@ -81,7 +81,7 @@ const AddOutreach = () => {
     if (doRedirect) redirect('/home')
 
     if (!auth?.checkAuth) return <Spinner />
-    if (auth?.user === "unauthenticated") return redirect('/')
+    if (auth?.isAuthenticated === "unauthenticated") return redirect('/')
 
     return (
         <form onSubmit={(e) => addOutreach(e)}>

--- a/client/app/outreach/add/page.jsx
+++ b/client/app/outreach/add/page.jsx
@@ -4,6 +4,8 @@ import Spinner from '@components/ui/Spinner'
 import { useAuthContext } from 'contexts/AuthContext'
 import { useState, useEffect } from 'react'
 import { redirect } from 'next/navigation'
+import { fetchClients } from '@utils/client'
+import Alert from '@components/ui/Alert'
 
 const AddOutreach = () => {
     const auth = useAuthContext()
@@ -29,43 +31,33 @@ const AddOutreach = () => {
         }
     })
     const [doRedirect, setDoRedirect] = useState(false)
-    const [error, setError] = useState('')
-    const [warn, setWarn] = useState('')
+    const [alert, setAlert] = useState({ message: '', type: '' })
     const [submitDisabled, setSubmitDisabled] = useState(false)
 
     useEffect(() => {
-        const fetchClients = async () => {
-            const clientsData = await fetch(`/server/client/getclients`, {
-                method: 'GET',
-                credentials: 'include'
-            })
-            const clientsJSON = await clientsData.json()
-            setClients(clientsJSON)
-        }
+        fetchClients().then(data => setClients(data))
         const fetchOutreaches = async () => {
-            const outreachData = await fetch(`/server/outreach/getoutreaches`, {
+            const outreachData = await fetch('/server/outreach/getoutreaches', {
                 method: 'GET',
                 credentials: 'include'
             })
             const outreachJSON = await outreachData.json()
             setOutreaches(outreachJSON)
         }
-        
         fetchOutreaches()
-        fetchClients()
     }, [])
 
     useEffect(() => {
-        if (clients.length === 1 && outreaches.length >= 1) setWarn('You have already reached out to this client!')
+        if (clients.length === 1 && outreaches.length >= 1) setAlert({ message: 'You have already reached out to this client!', type: 'warning' })
     }, [clients, outreach])
 
     const validationError = () => {
         if (!outreach.client) {
-            setError('Please select a client.')
+            setAlert({ message: 'Please select a client.', type: 'error' })
             return true
         }
         if (!outreach.contactDetails.contactMethod) {
-            setError('Please select a contact method.')
+            setAlert({ message: 'Please select a contact method.', type: 'error' })
             return true
         }
         return false
@@ -93,21 +85,14 @@ const AddOutreach = () => {
 
     return (
         <form onSubmit={(e) => addOutreach(e)}>
-            {error && <div class="alert alert-error">
-                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10 14l2-2m0 0l2-2m-2 2l-2-2m2 2l2 2m7-2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-                <span>{error}</span>
-            </div>}
-            {warn && <div class="alert alert-warning">
-                <svg xmlns="http://www.w3.org/2000/svg" class="stroke-current shrink-0 h-6 w-6" fill="none" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" /></svg>
-                <span>{warn}</span>
-            </div>}
+            {alert.message && <Alert message={alert.message} alertType={alert.type} />}
             <label htmlFor="client">Client:
                 <select
                     id="client"
                     value={outreach.client}
                     onChange={(e) => {
-                        if (outreaches.some(x => x.client === e.target.value)) setWarn('You have already reached out to this client!')
-                        else setWarn('')
+                        if (outreaches.some(x => x.client === e.target.value)) setAlert({ message: 'You have already reached out to this client!', type: 'warning' })
+                        else setAlert({})
                         if (e.target.value !== '') setOutreach({ ...outreach, client: e.target.value })
                     }}
                     className="select select-bordered w-full"

--- a/client/components/client/ClientCard.jsx
+++ b/client/components/client/ClientCard.jsx
@@ -1,18 +1,18 @@
 import React from 'react'
-import { EllipsisHorizontalIcon, PhoneIcon, EnvelopeIcon, MapPinIcon  } from '@heroicons/react/24/outline'
+import { EllipsisHorizontalIcon, PhoneIcon, EnvelopeIcon, MapPinIcon } from '@heroicons/react/24/outline'
 const ClientCard = ({ client }) => {
     return (
         <section className="client-card">
             <div>
                 <div className="flex justify-between">
-                    <h3 className="">{client.name}</h3>
+                    <h3 className="">{client.businessName}</h3>
                     <EllipsisHorizontalIcon className="h-8 w-8 text-accent stroke-1 hover:stroke-2 cursor-pointer" />
                 </div>
-                <hr/>
+                <hr />
                 <span className="text-sm italic">{client.businessType}</span>
                 <div className="client-contact">
                     <div className="contact-info-group">
-                        <PhoneIcon className="contact-icon me-4"/>
+                        <PhoneIcon className="contact-icon me-4" />
                         <p className="text-base">{client.phone}</p>
                     </div>
                     <div className="contact-info-group">

--- a/client/components/ui/Alert.jsx
+++ b/client/components/ui/Alert.jsx
@@ -1,0 +1,17 @@
+import { ExclamationTriangleIcon, CheckCircleIcon, InformationCircleIcon, XCircleIcon } from "@heroicons/react/24/outline"
+
+const Alert = ({ message, alertType }) => {
+    return (
+        <div className={`alert alert-${alertType}`}>
+
+            {alertType === "info" && <InformationCircleIcon className="w-6 h-6" />}
+            {alertType === "success" && <CheckCircleIcon className="w-6 h-6" />}
+            {alertType === "warning" && <ExclamationTriangleIcon className="w-6 h-6" />}
+            {alertType === "error" && <XCircleIcon className="w-6 h-6" />}
+
+            <span>{message}</span>
+        </div>
+    )
+}
+
+export default Alert

--- a/client/components/ui/Header.jsx
+++ b/client/components/ui/Header.jsx
@@ -52,6 +52,9 @@ const Header = ({ ThemeToggle }) => {
                             <li><Link href="/client/add">+ Client</Link></li>
                             <li><Link href="/outreach/add">+ Outreach</Link></li>
                             <li><Link href={'/settings'}>Settings</Link></li>
+                            {auth.user.admin &&
+                                <li><Link href={'/admin'}>Admin Tools</Link></li>
+                            }
                             <li><span className="pointer" onClick={logOut}>Logout</span></li>
                             <li><div className="form-control flex flex-row gap-1 mr-2">
                                 <ThemeToggle />

--- a/client/contexts/AuthContext/useProvideAuth.js
+++ b/client/contexts/AuthContext/useProvideAuth.js
@@ -36,7 +36,10 @@ const useProvideAuth = () => {
 
     const isAuthenticated = () => user ? true : 'unauthenticated'
 
+    const checkAuth = true
+
     return {
+        checkAuth,
         user,
         logout,
         isAuthenticated,

--- a/client/contexts/AuthContext/useProvideAuth.js
+++ b/client/contexts/AuthContext/useProvideAuth.js
@@ -4,6 +4,8 @@ import { useState, useEffect } from 'react'
 
 const useProvideAuth = () => {
     const [user, setUser] = useState(null)
+    const [isAuthenticated, setIsAuthenticated] = useState(false)
+    const [checkAuth, setCheckAuth] = useState(false)
 
     useEffect(() => {
         const fetchCurrentUser = async () => {
@@ -17,12 +19,10 @@ const useProvideAuth = () => {
             } catch (err) {
                 // No user
                 setUser(null)
-            }
-            if (response instanceof Object) {
-                // To-do: put redirect logic here
+                setIsAuthenticated('unauthenticated')
             }
         }
-        fetchCurrentUser()
+        fetchCurrentUser().then(data => setCheckAuth(true))
     }, [])
 
     const logout = async () => {
@@ -33,10 +33,6 @@ const useProvideAuth = () => {
         })
         setUser(null)
     }
-
-    const isAuthenticated = () => user ? true : 'unauthenticated'
-
-    const checkAuth = true
 
     return {
         checkAuth,

--- a/client/styles/globals.css
+++ b/client/styles/globals.css
@@ -8,32 +8,20 @@
 	--background-end-rgb: 255, 255, 255;
 }
 
-/* @media (prefers-color-scheme: dark) {
-	:root {
-		--foreground-rgb: 255, 255, 255;
-		--background-start-rgb: 0, 0, 0;
-		--background-end-rgb: 0, 0, 0;
-	}
-} */
-
 body {
 	display: flex;
 	flex-direction: column;
 	justify-content: space-between;
 	min-height: 100vh;
-	@apply  gap-5;
+	@apply gap-5;
 }
 
 .content {
-	@apply flex flex-col gap-5 px-10 md:px-20;
+	@apply flex flex-col gap-5 px-10 md:px-20 flex-1;
 }
 
 h2 {
 	@apply mt-5 mb-3 text-2xl font-extrabold leading-[1.15] sm:text-3xl;
-}
-
-.pointer:hover {
-	cursor: pointer;
 }
 
 /* Client Card */
@@ -45,11 +33,13 @@ h2 {
 .client-contact {
 	@apply text-xs text-secondary p-2 mt-2;
 }
-.contact-info-group{
-    @apply flex items-center mb-2;
+
+.contact-info-group {
+	@apply flex items-center mb-2;
 }
+
 .contact-icon {
-    @apply w-7 h-7 text-accent stroke-2;
+	@apply w-7 h-7 text-accent stroke-2;
 }
 
 h3 {
@@ -63,8 +53,7 @@ h4 {
 /* UI */
 
 hr {
-	border: none;
-	@apply bg-secondary w-full h-[1px];
+	@apply w-full max-w-[500px] border-0 rounded-full mx-auto h-[2px] bg-accent;
 }
 
 /* Forms */
@@ -74,7 +63,7 @@ form {
 }
 
 .button-form-submit {
-    @apply btn btn-accent bg-transparent text-accent text-lg border-4 hover:bg-accent hover:text-secondary hover:opacity-100;
+	@apply btn btn-accent bg-transparent text-accent text-lg border-4 hover:bg-accent hover:text-secondary hover:opacity-100;
 }
 
 input:not([type="checkbox"]) {
@@ -82,16 +71,21 @@ input:not([type="checkbox"]) {
 }
 
 .input-add {
-    @apply w-full rounded p-1;
+	@apply w-full rounded p-1;
 }
+
 .select {
-    @apply w-full rounded p-1 text-secondary bg-primary;
+	@apply w-full rounded p-1 text-secondary bg-primary;
 }
 
 .navbar {
-    @apply flex justify-between p-4;
+	@apply flex justify-between p-4;
 }
 
-.action-icon{
-    @apply w-7 h-7 mx-1 cursor-pointer text-secondary;
+.action-icon {
+	@apply w-7 h-7 mx-1 cursor-pointer text-secondary;
+}
+
+.text-submit {
+	@apply bg-transparent w-auto h-auto p-0 m-0 text-base font-bold;
 }

--- a/client/utils/client.js
+++ b/client/utils/client.js
@@ -1,0 +1,8 @@
+export const fetchClients = async () => {
+    const clientsData = await fetch('/server/client/getclients', {
+        method: 'GET',
+        credentials: 'include'
+    })
+    const clientsJSON = await clientsData.json()
+    return clientsJSON
+}

--- a/server/compose.yaml
+++ b/server/compose.yaml
@@ -2,6 +2,7 @@
 services:
   mongo:
     image: mongo:6 
+    container_name: 100freelancers
     ports:
       - "27017:27017"
     environment:

--- a/server/config/mockClients.json
+++ b/server/config/mockClients.json
@@ -1,0 +1,37 @@
+[
+    {
+        "businessName": "Outshine Salon",
+        "businessType": "hair salon",
+        "phone": "(904) 756-2648",
+        "email": "outshine@salon.com",
+        "address": "555 Main Street, Houston, TX 12345"
+    },
+    {
+        "businessName": "Homegrown Brunch Cafe",
+        "businessType": "restaurant",
+        "phone": "(944) 724-1618",
+        "email": "homegrown@brunch.com",
+        "address": "555 Main Street, Houston, TX 12345"
+    },
+    {
+        "businessName": "Functional Fitness",
+        "businessType": "gym",
+        "phone": "(346) 754-1577",
+        "email": "functional@fitness.com",
+        "address": "555 Main Street, Houston, TX 12345"
+    },
+    {
+        "businessName": "O-Marketing",
+        "businessType": "marketing",
+        "phone": "(246) 755-1447",
+        "email": "o@marketing.com",
+        "address": "555 Main Street, Houston, TX 12345"
+    },
+    {
+        "businessName": "Nails Plus",
+        "businessType": "nail salon",
+        "phone": "(166) 733-1248",
+        "email": "nails@plus.com",
+        "address": "555 Main Street, Houston, TX 12345"
+    }
+]

--- a/server/controllers/client.js
+++ b/server/controllers/client.js
@@ -1,16 +1,18 @@
 const Client = require('../models/Client')
+const mockUser = require('../config/mockUser.json')
 
 module.exports = {
     getClients: async (req, res) => {
-        const userId = req.user.id
+        const userId = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
         const clients = await Client.find({ user: userId }).sort({ businessName: 1 }).lean()
         res.json(clients)
     },
     addClient: async (req, res) => {
         try {
+            const user = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
             const { businessName, businessType, address, email, phone } = req.body
             const client = await Client.create({
-                user: req.user.id,
+                user: user,
                 businessName,
                 businessType,
                 address,

--- a/server/controllers/dev.js
+++ b/server/controllers/dev.js
@@ -1,0 +1,13 @@
+const Client = require('../models/Client')
+const mockClients = require('../config/mockClients.json')
+
+module.exports = {
+    loadMockClients: async (req, res) => {
+        try {
+            await Client.insertMany(mockClients)
+            res.send({ success: true })
+        } catch (err) {
+            res.send({ success: false, error: err })
+        }
+    }
+}

--- a/server/controllers/dev.js
+++ b/server/controllers/dev.js
@@ -4,16 +4,21 @@ const mockUser = require('../config/mockUser.json')
 
 module.exports = {
     loadMockClients: async (req, res) => {
-        try {
-            const user = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
-            let mockClientsWithUser = mockClients
-            for (let client of mockClientsWithUser) {
-                client.user = user
+        if (process.env.NODE_ENV === 'local') {
+            try {
+                const user = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
+                let mockClientsWithUser = mockClients
+                for (let client of mockClientsWithUser) {
+                    client.user = user
+                }
+                await Client.insertMany(mockClients)
+                res.send({ success: true })
+            } catch (err) {
+                res.send({ success: false, error: err })
             }
-            await Client.insertMany(mockClients)
-            res.send({ success: true })
-        } catch (err) {
-            res.send({ success: false, error: err })
+        } else {
+            console.log('Mock clients cannot be loaded into the DB in prod')
+            res.send({ message: 'Mock clients cannot be loaded into the DB in prod' })
         }
     }
 }

--- a/server/controllers/dev.js
+++ b/server/controllers/dev.js
@@ -1,9 +1,15 @@
 const Client = require('../models/Client')
 const mockClients = require('../config/mockClients.json')
+const mockUser = require('../config/mockUser.json')
 
 module.exports = {
     loadMockClients: async (req, res) => {
         try {
+            const user = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
+            let mockClientsWithUser = mockClients
+            for (let client of mockClientsWithUser) {
+                client.user = user
+            }
             await Client.insertMany(mockClients)
             res.send({ success: true })
         } catch (err) {

--- a/server/controllers/outreach.js
+++ b/server/controllers/outreach.js
@@ -1,17 +1,19 @@
 const Outreach = require('../models/Outreach')
+const mockUser = require('../config/mockUser.json')
 
 module.exports = {
     getOutreaches: async (req, res) => {
-        console.log(req.user)
-        const userId = req.user.id
+        const userId = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
         const outreaches = await Outreach.find({ user: userId }).sort({ createdAt: -1 }).lean()
         res.json(outreaches)
     },
     addOutreach: async (req, res) => {
+        console.log(req.user)
         try {
+            const user = process.env.MOCK_USER === "true" ? mockUser._id : req.user.id
             const { client, contactDetails, responseDetails, clientWork } = req.body
             const outreach = await Outreach.create({
-                user: req.user.id,
+                user: user,
                 client: client,
                 contactDetails,
                 responseDetails,

--- a/server/index.js
+++ b/server/index.js
@@ -85,11 +85,13 @@ const homeRoutes = require('./routes/home')
 const authRoutes = require('./routes/auth')
 const clientRoutes = require('./routes/client')
 const outreachRoutes = require('./routes/outreach')
+const devRoutes = require('./routes/dev')
 
 app.use('/server/', homeRoutes)
 app.use('/server/auth', authRoutes)
 app.use('/server/client', clientRoutes)
 app.use('/server/outreach', outreachRoutes)
+app.use('/server/dev', devRoutes)
 
 connectDB().then(() => {
     app.listen(process.env.PORT || PORT, () => {

--- a/server/models/Outreach.js
+++ b/server/models/Outreach.js
@@ -2,8 +2,8 @@ const mongoose = require('mongoose')
 const { Schema, model, models } = mongoose
 
 const OutreachSchema = new Schema({
-    user: {type: Schema.Types.ObjectId, ref: 'User'},
-    client: {type: Schema.Types.ObjectId, ref: 'Client'},
+    user: { type: Schema.Types.ObjectId, ref: 'User' },
+    client: { type: Schema.Types.ObjectId, ref: 'Client' },
     contactDetails: {
         contacted: {
             type: Boolean,

--- a/server/routes/dev.js
+++ b/server/routes/dev.js
@@ -1,0 +1,7 @@
+const express = require('express')
+const router = express.Router()
+const devController = require('../controllers/dev')
+
+router.post('/loadmockclients', devController.loadMockClients)
+
+module.exports = router


### PR DESCRIPTION
**Description**
- Home page now shows real client data from the DB rather then the previous dummy data
- Created an Admin Tools page for admin users
- In development, mock clients can be quickly loaded into the DB for quick and easy testing from the Admin Tools page
- Minor styling edits

Bugs fixed:
- Users should no longer be booted to the landing page before the auth context can run
- Adding clients and outreach in development should work as intended (previously, `user` field was not being properly added)

**Testing**
Manually tested adding clients & outreach, checked each page to verify users are properly authenticated and not needlessly booted to the landing page, quick-loaded mock clients using the new admin tool.