### PR TITLE
Bugfix: Filter option dupes, case-sensitivity

### DIFF
--- a/client/app/home/page.jsx
+++ b/client/app/home/page.jsx
@@ -11,12 +11,12 @@ import { fetchClients } from '@utils/client'
 const Home = () => {
     const auth = useAuthContext()
     const [clients, setClients] = useState(null)
-    const [filteringOptions, setFilteringOptions] = useState([]); // Add state for filtering options
+    const [filteringOptions, setFilteringOptions] = useState([])
 
     useEffect(() => {
         fetchClients().then(data => {
             setClients(data)
-            setFilteringOptions(data); // Initialize filteringOptions with the fetched data
+            setFilteringOptions(data)
         })
     }, [auth?.user])
 
@@ -25,26 +25,27 @@ const Home = () => {
 
     function sortClients(sortingFunction) {
         // Clone the clients array and sort it using the provided sorting function.
-        const sortedClients = [...clients].sort(sortingFunction);
-        setClients(sortedClients);  // We set the clients state variable with sorted array
-    };
+        const sortedClients = [...clients].sort(sortingFunction)
+        setClients(sortedClients)
+    }
 
     function filterClients(data) {
-        setClients(data) // We set the clients state variable with the filtered array coming from action menu component
+        setClients(data)
     }
 
     function clearFilter() {
-        setClients(filteringOptions); // We reset the clients state variable with the original data from the server
-    };
-    
+        // Reset 'clients' to original data from the server
+        setClients(filteringOptions)
+    }
+
     return (
         <>
             <div className="px-8 pb-4">
-                <ActionMenu 
-                    sortClients={sortClients} 
-                    filterClients={filterClients} 
-                    filteringOptions={filteringOptions} 
-                    clearFilter={clearFilter} 
+                <ActionMenu
+                    sortClients={sortClients}
+                    filterClients={filterClients}
+                    filteringOptions={filteringOptions}
+                    clearFilter={clearFilter}
                 />
             </div>
 

--- a/client/components/ui/ActionMenu.jsx
+++ b/client/components/ui/ActionMenu.jsx
@@ -31,7 +31,7 @@ const ActionMenu = ({ sortClients, filterClients, clearFilter, filteringOptions 
 
         let filteredData = filteringOptions.filter((option) =>
             // We get an array of filteredData based on the filtering values
-            updateFilters.includes(option.businessType)
+            updateFilters.includes(option.businessType.toLowerCase())
         )
 
 
@@ -49,15 +49,21 @@ const ActionMenu = ({ sortClients, filterClients, clearFilter, filteringOptions 
         clearFilter()
     }
 
-    const filterOptionElements = filteringOptions?.map((option, i) => {
+    const businessTypesList = [...new Set(
+        filteringOptions
+            ?.map((client, i) => client.businessType.toLowerCase())
+            .sort()
+    )]
+
+    const filterOptionElements = businessTypesList?.map((option, i) => {
         return (
             <label key={i} className='label '>
-                <span className="label-text">{option.businessType}</span>
+                <span className="label-text capitalize">{option}</span>
                 <input
                     type='checkbox'
-                    value={option.businessType}
-                    checked={currentFilter.includes(option.businessType)}
-                    onChange={(e) => handleFiltering(e, option.businessType)}
+                    value={option}
+                    checked={currentFilter.includes(option)}
+                    onChange={(e) => handleFiltering(e, option)}
                     className='checkbox'
                 />
             </label>

--- a/server/controllers/client.js
+++ b/server/controllers/client.js
@@ -14,7 +14,7 @@ module.exports = {
             const client = await Client.create({
                 user: user,
                 businessName,
-                businessType,
+                businessType: businessType.toLowerCase(),
                 address,
                 email,
                 phone


### PR DESCRIPTION
### Description

- The filter options list was showing duplicates, this has been fixed
- Filter options dropdown shows the business types in alphabetical order
- Filtering was case-sensitive; made it case-insensitive, and forced all new clients to store `businessType` as a lowercase string

### Testing

Manually verified that filtering still works, and that adding a new client automatically lowercases the `businessType`.

### Did you change the schema?

- [ ] Yes
- [x] No

### Issue

N/A



